### PR TITLE
Add Scroll Margin to Sections for Better Anchor Navigation

### DIFF
--- a/app/components/Articles.tsx
+++ b/app/components/Articles.tsx
@@ -3,7 +3,7 @@ import SectionTitle from "./SectionTitle";
 
 const Articles = () => {
   return (
-    <section id="articles" className="flex flex-col">
+    <section id="articles" className="flex flex-col scroll-mt-11">
       <SectionTitle title="Articles & Videos" />
 
       <div className="group/list flex flex-col gap-16">

--- a/app/components/ExperienceSection.tsx
+++ b/app/components/ExperienceSection.tsx
@@ -51,7 +51,7 @@ const renderExperience = (experience: Experience) => {
 
 const ExperienceSection = () => {
   return (
-    <section id="experience">
+    <section id="experience" className="scroll-mt-11">
       <SectionTitle title="Experience" />
 
       <ul className="group/list flex flex-col gap-4">

--- a/app/components/PersonalProjectPreviews.tsx
+++ b/app/components/PersonalProjectPreviews.tsx
@@ -79,7 +79,7 @@ const renderProject = (project: Project) => {
 
 const PersonalProjectPreviews = () => {
   return (
-    <section id="personal-projects" className="flex flex-col">
+    <section id="personal-projects" className="flex flex-col scroll-mt-11">
       <SectionTitle title="Personal Projects" />
 
       {/* PROJECT PREVIEWS */}

--- a/app/components/ProjectPreviews.tsx
+++ b/app/components/ProjectPreviews.tsx
@@ -80,7 +80,7 @@ const renderProject = (project: Project) => {
 
 const ProjectPreviews = () => {
   return (
-    <section id="professional-projects" className="flex flex-col">
+    <section id="professional-projects" className="flex flex-col scroll-mt-11">
       <SectionTitle title="Professional Projects" />
       {/* PROJECT PREVIEWS */}
       <div className="group/list flex flex-col gap-16">


### PR DESCRIPTION
# Pull Request: Add Scroll Margin to Sections for Better Anchor Navigation

## Description
This PR improves the anchor navigation experience by adding a top scroll margin (`scroll-mt-11`) to the `#professional-projects` section (and similar sections as needed).  
Now, when users navigate via hash links or the sidebar navigation, each section will have appropriate space at the top, preventing headings from being hidden behind sticky headers or appearing cramped.

---

## Changes
- Added the `scroll-mt-11` Tailwind class to the section element in `ProjectPreviews.tsx`.  
- Ensured consistent spacing for anchor navigation across the site.  

---

## Why
Previously, navigating to a section via hash link would align the section flush with the top of the viewport, often hiding the heading behind sticky navigation or making the layout feel cramped.  
This update provides a smoother and more visually consistent navigation experience.  

---

## Closes
- Anchor navigation spacing issues  
- Headings hidden behind sticky nav  
